### PR TITLE
Removing the light switch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,10 +60,7 @@ module.exports = {
       ],
     },
     colorMode: {
-      switchConfig: {
-        lightIcon: ' ',
-        darkIcon: ' ',
-      }
+      disableSwitch: true,
     },
     footer: {
       style: 'dark',


### PR DESCRIPTION
This pull-request removes the light-switch at the top right:

![image](https://user-images.githubusercontent.com/316665/111924490-27fc1180-8aa5-11eb-8f7c-c4174de53b1e.png)

as I feel it gives too much choice for an official website. Also I would remove the "Fork Me On GitHub!" button, eventually, as I though it would lead to https://gitlab.com/tezos/tezos , but that is through this button that I found the repository of this website.

Also, I was making a new page with Docusaurus for a Coq project at Nomadic Labs https://gitlab.com/nomadic-labs/coq-tezos-of-ocaml/-/merge_requests/42 , so the two websites look very similar! At least I am not alone I guess.