### PR TITLE
Added "Ecosystem" tab to the navbar of tezos.com site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.docusaurus

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,6 +59,11 @@ module.exports = {
           position: 'left'
         },
         {
+          to: 'https://tezosprojects.com/',
+          label: 'Ecosystem',
+          position: 'left'
+        },
+        {
           type: 'localeDropdown',
           position: 'right'
         },


### PR DESCRIPTION
The "Ecosystem" tab redirects the site to "https://tezosprojects.com/", where tezos project can be seen in an organized way.

Issue resolved : #61

![tezos](https://user-images.githubusercontent.com/66105983/122687461-40123700-d234-11eb-9cbc-eaa9fce31728.png)

